### PR TITLE
Ultra opinionated style changes

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -108,13 +108,12 @@ img {
 .container {
     width: 100%;
     min-height: 98vh;
-    padding-top: 50px;
     padding-bottom: 11.5rem;
 }
 
 .main {
     margin: 0 auto;
-    margin-top: .75em;
+    margin-top: 3.75em;
     padding: 0 .75em;
     max-width: var(--max-width);
     line-height: 1.4;
@@ -155,7 +154,7 @@ hr {
     background: var(--jumbotron-bg);
     box-shadow: 0 1px 5px rgba(0, 0, 0, 0.6);
     color: var(--jumbotron-text-color);
-    padding: 2em 0;
+    padding: 8em 0 4em 0;
 }
 
 .child {
@@ -272,6 +271,7 @@ h1 {
 .art-info h1 {
     margin-top: 0;
     display: inline;
+    margin-right: 2em;
 }
 
 .art-body {
@@ -290,7 +290,7 @@ h1 {
 
 .art-date {
     display: inline-block;
-    text-align: baseline;
+    vertical-align: baseline;
     line-height: 1;
     white-space: nowrap;
     color: var(--art-date-color);
@@ -340,12 +340,14 @@ h1 {
     margin-top: 2vh;
     box-shadow: 0 -3px 5px rgba(150,150,150,.36);
     min-height: 9.5rem;
+
+    padding: 3em 0;
 }
 
 .footer-container {
     display: flex;
     flex-wrap: wrap;
-    justify-content: space-between;
+    justify-content: center;
     align-items: flex-start;
     margin: 0 auto;
 }
@@ -353,7 +355,8 @@ h1 {
 .footerchild {
     margin: 0 2em;
     margin-top: .5em;
-    flex: 1 1 1px;
+    flex-grow: 1;
+    flex-shrink: 0;
 }
 
 .footerchild:last-child {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -198,7 +198,7 @@ img.icon {
     background-color: var(--box-hover-color);
 }
 
-.box div{
+.box span {
     position: relative;
     top: initial;
     font-size: 20px;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -237,13 +237,13 @@ hr {
         margin: 0 .5em;
     }
 
-    .box div {
+    .box span {
         font-size: 22px;
         line-height: 22px;
         padding-left: 8px;
-        font-weight: 700;
+        font-weight: bold;
         position: relative;
-        display: inline;
+        display: inline-block;
         text-align: center;
     }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -149,6 +149,7 @@ hr {
 /* jumbotron */
 .jumbotron {
     position: relative;
+    z-index: 100;
     width: 100%;
     margin-top: -16px;
     background: var(--jumbotron-bg);
@@ -157,12 +158,18 @@ hr {
     padding: 8em 0 4em 0;
 }
 
-.child {
+.tagline {
     text-align: center;
     margin: .5em auto;
     font-size: 32px;
     line-height: 48px;
     max-width: 75%;
+    margin-bottom: 2em;
+}
+
+img.icon {
+    display: block;
+    margin: 25px auto;
 }
 
 .box-container {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -292,7 +292,7 @@ h1 {
 }
 
 .artlist.heading {
-    margin: 8em 0 2em 0;
+    margin: 8em auto 2em auto;
     padding: 0 0.75em;
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -267,7 +267,7 @@ h1 {
 }
 
 .art-info {
-    line-height: 1.6;
+    line-height: 2.1;
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
@@ -289,6 +289,11 @@ h1 {
     max-width: var(--max-width);
     margin: 0 auto;
     margin-top: .5em;
+}
+
+.artlist.heading {
+    margin: 8em 0 2em 0;
+    padding: 0 0.75em;
 }
 
 .artlist .art-info:not(:first-child) {

--- a/templates/artlist.html
+++ b/templates/artlist.html
@@ -2,6 +2,9 @@
 {% extends "base.html" %}
 {% set title = "archive" %}
 {% block content %}
+<div class="artlist heading">
+    <h1>Blog Archive</h1>
+</div>
 <div class="artlist main">
 {% for article in get_module("news").articles|reverse %}
     {{ artinfo.info(article, "b") }}

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,15 +7,15 @@
     <div class="box-container">
         <a class="box" href="#">
             <i class="fa fa-comment fa-4x"></i>
-            <div>Chat</div>
+            <span>Chat</span>
         </a>
         <a class="box" href="#">
             <i class="fa fa-users fa-4x"></i>
-            <div>Register a group</div>
+            <span>Register a group</span>
         </a>
         <a class="box" href="#">
             <i class="fa fa-question fa-4x"></i>
-            <div href="#">FAQ</div>
+            <span href="#">FAQ</span>
         </a>
     </div>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,8 @@
 {% import "artinfo.html" as artinfo %}
 {% block content %}
 <div class="jumbotron">
-    <h2 class="child">Welcome to freenode&thinsp;—&thinsp;supporting free and open source communities since 1998</h2>
+    <img src="static/img/logos/coloured-alphabg.svg" alt="freenode" class="icon">
+    <p class="tagline">Supporting free and open source communities since 1998</h2>
     <div class="box-container">
         <a class="box" href="#">
             <i class="fa fa-comment fa-4x"></i>


### PR DESCRIPTION
These are the changes this PR adds:

1) The jumbotron covers the fixed header bar, this makes everything look cleaner. When scrolling to the article view, the header bar is uncovered and shown like normally. (Maybe this should be removed on mobile, replaced with an absolutely positioned bar of some sort or something?)  

![show off 1](https://cloud.githubusercontent.com/assets/358714/13376826/95ba4db6-ddcd-11e5-86ca-f06b5da5827a.png)

2) There's some breathing room between various UI elements

Articles and the jumbotron:  
![article and jumbotron margins](https://cloud.githubusercontent.com/assets/358714/13376830/aae71e3a-ddcd-11e5-9376-d13984e3ffe0.png)

Articles in the archive:  
![article margins](https://cloud.githubusercontent.com/assets/358714/13376836/f3f9b7a4-ddcd-11e5-9bd4-bdc0f2114fa5.png)


3) The Archive page has a title now:

![archive page title](https://cloud.githubusercontent.com/assets/358714/13376837/0ee959ca-ddce-11e5-84e6-aba3075ce5ca.png)

