### PR TITLE
Revamp the jumbotron, now looking 100% more clean and 75% more epic.

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -151,11 +151,25 @@ hr {
     position: relative;
     z-index: 100;
     width: 100%;
-    margin-top: -16px;
     background: var(--jumbotron-bg);
     box-shadow: 0 1px 5px rgba(0, 0, 0, 0.6);
     color: var(--jumbotron-text-color);
     padding: 2em 0;
+}
+
+.jumbotron .pia_logo {
+    position: absolute;
+    height: 40px;
+    right: 0; 
+    top: 0;
+    margin: 25px;
+}
+
+
+@media (--max-sm) {
+    .jumbotron .icon {
+        margin-top: 60px;
+    }
 }
 
 .tagline {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -150,6 +150,7 @@ hr {
 /* jumbotron */
 .jumbotron {
     position: relative;
+    z-index: 100;
     width: 100%;
     margin-top: -16px;
     background: var(--jumbotron-bg);
@@ -158,12 +159,18 @@ hr {
     padding: 2em 0;
 }
 
-.child {
+.tagline {
     text-align: center;
     margin: .5em auto;
     font-size: 32px;
     line-height: 48px;
     max-width: 75%;
+    margin-bottom: 2em;
+}
+
+img.icon {
+    display: block;
+    margin: 25px auto;
 }
 
 .box-container {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -108,7 +108,6 @@ img {
 .container {
     width: 100%;
     min-height: 98vh;
-    padding-top: 50px;
     padding-bottom: 11.5rem;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,8 @@
 {% import "artinfo.html" as artinfo %}
 {% block content %}
 <div class="jumbotron">
-    <img src="static/img/logos/coloured-alphabg.svg" alt="freenode" class="icon">
+    <img class="pia_logo" src="{{ url_for("static/img/logos/PIALogo_white.svg") }}">
+    <img src="{{ url_for("static/img/logos/coloured-alphabg.svg") }}" alt="freenode" class="icon">
     <p class="tagline">Supporting free and open source communities since 1998</h2>
     <div class="box-container">
         <a class="box" href="{{ url_for("faq/index/chat") }}">

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,8 @@
 {% import "artinfo.html" as artinfo %}
 {% block content %}
 <div class="jumbotron">
-    <h2 class="child">Welcome to freenode&thinsp;—&thinsp;supporting free and open source communities since 1998</h2>
+    <img src="static/img/logos/coloured-alphabg.svg" alt="freenode" class="icon">
+    <p class="tagline">Supporting free and open source communities since 1998</h2>
     <div class="box-container">
         <a class="box" href="{{ url_for("faq/index/chat") }}">
             <i class="fa fa-comment fa-4x"></i>


### PR DESCRIPTION
Here's what the new design would look like (browser UI starts directly above the image):

![show off 1](https://cloud.githubusercontent.com/assets/358714/13376826/95ba4db6-ddcd-11e5-86ca-f06b5da5827a.png)

The top bar is still there - it will be shown when the user passes the splash part of the page into the blog / footer area.