### PR TITLE
README.md: use sudo with npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A shiny replacement for http://freenode.net.
 You'll need our node.js dependencies:
 
 ```console
-$ npm install -g myth svgo
+$ sudo npm install -g myth svgo
 ```
 
 Then, assuming a Python 3.4 (or later) installation:


### PR DESCRIPTION
At least with Arch Linux you must be root in order to use the `-g` flag with `npm install`.

I assume that it's preferable to use `sudo` instead of changing the `$` to `#`.