### PR TITLE
Sasl documentation

### DIFF
--- a/config/kb.yml
+++ b/config/kb.yml
@@ -3,7 +3,7 @@ chat:
   cats: [connect,general]
 all:
   title: 'Knowledge Base'
-  cats: [connect,general,using]
+  cats: [connect,general,using,sasl]
 tech:
   title: 'Technical'
   cats: []

--- a/config/kb.yml
+++ b/config/kb.yml
@@ -3,7 +3,7 @@ chat:
   cats: [connect,general]
 all:
   title: 'Knowledge Base'
-  cats: [connect,general,using,sasl]
+  cats: [connect,general,using]
 tech:
   title: 'Technical'
   cats: []

--- a/content/kb/sasl/chatzilla.md
+++ b/content/kb/sasl/chatzilla.md
@@ -1,0 +1,10 @@
+Title: Configuring SASL for Chatzilla
+---
+This script is by Gryllida, for the [ChatZilla add-on](https://addons.mozilla.org/addon/16) to Firefox.
+
+1. Install [cz_sasl.js](http://freenode-dev.net/sasl/cz_sasl.js) as you would any other script, following the [instructions here](http://chatzilla.hacksrus.com/faq/#install-script).
+2. Enter the commands below. Replace `YOUR_USERNAME` with your registered nickname and `YOUR_PASSWORD` with your NickServ password.
+3. If you want to continue connecting when SASL authentication fails, enter: `/plugin-pref cz_sasl sasl.proceed_on_fail true`
+4. If everything has been configured correctly, the next time you connect you should see the message:
+
+`SASL authentication successful`

--- a/content/kb/sasl/chatzilla.md
+++ b/content/kb/sasl/chatzilla.md
@@ -1,8 +1,8 @@
 Title: Configuring SASL for Chatzilla
 ---
-This script is by Gryllida, for the [ChatZilla add-on](https://addons.mozilla.org/addon/16) to Firefox.
+This script is by Gryllida, for the [ChatZilla add-on <i class="fa fa-external-link" aria-hidden="true"></i>](https://addons.mozilla.org/addon/16 ) to Firefox.
 
-1. Install [cz_sasl.js](http://freenode-dev.net/sasl/cz_sasl.js) as you would any other script, following the [instructions here](http://chatzilla.hacksrus.com/faq/#install-script).
+1. Install [cz_sasl.js <i class="fa fa-external-link" aria-hidden="true"></i>](http://freenode-dev.net/sasl/cz_sasl.js) as you would any other script, following the [instructions here <i class="fa fa-external-link" aria-hidden="true"></i>](http://chatzilla.hacksrus.com/faq/#install-script).
 2. Enter the commands below. Replace `YOUR_USERNAME` with your registered nickname and `YOUR_PASSWORD` with your NickServ password.
 3. If you want to continue connecting when SASL authentication fails, enter: `/plugin-pref cz_sasl sasl.proceed_on_fail true`
 4. If everything has been configured correctly, the next time you connect you should see the message:

--- a/content/kb/sasl/epic5.md
+++ b/content/kb/sasl/epic5.md
@@ -1,0 +1,16 @@
+Title: Configuring SASL for Epic5
+---
+EPIC5 has the sasl_auth script built-in. Mikhail contributed this explanation of how to use it.
+
+Open your EPIC5 configuration file, ~/.epicrc or ~/.ircrc, in your preferred editor.
+Add the following lines:
+
+ * `load sasl_auth`
+ * `sasl_auth *.freenode.net plain username password`
+
+Replace username with your primary nick. The password may be replaced with your password or omitted, in which case EPIC5 will prompt for the password when it connects.
+You may change `*.freenode.net` to something more specific if desired, but the * means SASL authentication will be attempted for any freenode.net server.
+Only `plain` is supported as the authentication mechanism. You may want to use SSL to protect your password.
+
+If everything has been configured correctly, the next time you connect you should see the message:
+  `SASL authentication successful`

--- a/content/kb/sasl/hexchat.md
+++ b/content/kb/sasl/hexchat.md
@@ -1,0 +1,13 @@
+Title: Configuring SASL for Hexchat
+---
+These instructions were originally contributed by BlueShark. Thanks!
+
+HexChat is a fork of XChat has in-built SASL support. It doesn't require any additional scripts for that purpose. The setup procedure is simple.
+
+1. Open the Network List (Ctrl + S)
+2. The freenode network may already exist; find it in the list then click on Edit
+3. In the username field, enter your primary nick
+4. Select `SASL (username + password)` for the Login method field
+5. In the SASL password field, enter your NickServ password
+
+If everything was configured correctly, you should see a `SASL authentication successful` message when you connect. You will already be identified to NickServ, so you don't need to do this again.

--- a/content/kb/sasl/irssi.md
+++ b/content/kb/sasl/irssi.md
@@ -1,0 +1,21 @@
+Title: Configuring SASL for irssi
+---
+This script, originally by Michael Tharp and Jilles Tjoelker has been further developed by Mantas Mikulėnas (grawity) and lives on scripts.irssi.org. Authentication information may be stored in ~/.irssi/sasl.auth.
+
+1. Copy the script, [cap_sasl.pl](http://scripts.irssi.org/scripts/cap_sasl.pl), into your ~/.irssi/scripts/autorun directory or from wherever irssi loads startup scripts.
+2. The script requires at least the Perl module [MIME::Base64](https://metacpan.org/module/MIME::Base64). If you're using Linux, Perl modules are generally in distribution repositories, or you can get them directly from CPAN. If you cannot install them for the whole system, you may be able to use [local::lib](https://metacpan.org/module/local::lib).
+3. Load the script using `/script load autorun/cap_sasl.pl`.
+4. The script needs to be configured with `/sasl set network nick password mechanism`.
+
+   `network` is the (case-sensitive) name of the network specified with `/network add`
+
+   `nick` is your registered nickname
+
+   `password` is your NickServ password
+
+   `mechanism` should be `PLAIN`. `PLAIN` sends your password unprotected, as plain text (which is fine when connecting over SSL, as the entire exchange is encrypted already).
+5. Save the settings with `/sasl save`
+6. If everything has been configured correctly, the next time you connect you should see the message:
+`SASL authentication successful`
+
+The script also supports `/sasl show` and `/sasl load`. Show lists currently-configured networks and the saved credentials. Load re-reads the sasl.auth file. A `/sasl set network` command with no other arguments will delete the configuration for that network.

--- a/content/kb/sasl/irssi.md
+++ b/content/kb/sasl/irssi.md
@@ -2,8 +2,8 @@ Title: Configuring SASL for irssi
 ---
 This script, originally by Michael Tharp and Jilles Tjoelker has been further developed by Mantas Mikulėnas (grawity) and lives on scripts.irssi.org. Authentication information may be stored in ~/.irssi/sasl.auth.
 
-1. Copy the script, [cap_sasl.pl](http://scripts.irssi.org/scripts/cap_sasl.pl), into your ~/.irssi/scripts/autorun directory or from wherever irssi loads startup scripts.
-2. The script requires at least the Perl module [MIME::Base64](https://metacpan.org/module/MIME::Base64). If you're using Linux, Perl modules are generally in distribution repositories, or you can get them directly from CPAN. If you cannot install them for the whole system, you may be able to use [local::lib](https://metacpan.org/module/local::lib).
+1. Copy the script, [cap_sasl.pl <i class="fa fa-external-link" aria-hidden="true"></i>](http://scripts.irssi.org/scripts/cap_sasl.pl), into your ~/.irssi/scripts/autorun directory or from wherever irssi loads startup scripts.
+2. The script requires at least the Perl module [MIME::Base64 <i class="fa fa-external-link" aria-hidden="true"></i>](https://metacpan.org/module/MIME::Base64). If you're using Linux, Perl modules are generally in distribution repositories, or you can get them directly from CPAN. If you cannot install them for the whole system, you may be able to use [local::lib <i class="fa fa-external-link" aria-hidden="true"></i>](https://metacpan.org/module/local::lib).
 3. Load the script using `/script load autorun/cap_sasl.pl`.
 4. The script needs to be configured with `/sasl set network nick password mechanism`.
 

--- a/content/kb/sasl/kvirc.md
+++ b/content/kb/sasl/kvirc.md
@@ -1,0 +1,15 @@
+Title: Configuring SASL for KVIrc
+---
+
+If you have already added freenode as a network, open your servers window, select the freenode server, and skip to step five.
+
+1. Click Settings, and the Configure Servers
+2. Anywhere in the Servers window that appears, right click and select New network
+3. Enter a name (perhaps freenode)
+4. Right click on the network you just added, and click New Server
+5. Enter chat.freenode.net as the server name, and then click Advanced
+6. In the Connection tab, enter 6697 for the port, then check the "Use SSL Protocol" checkbox
+7. Select the Advanced tab, Enable the "Query extended capabilities on connect" option, as well as the Authenticate via SASL extension. In the SASL nickname field, enter your freenode account name. In the SASL password field, enter your NickServ password
+8. Click OK, until you have returned to the Servers window, and then click the Connect Now button
+
+If everything was configured correctly, you should see a `SASL authentication successful` message when you connect. You will already be identified, so you don't need to do this again.

--- a/content/kb/sasl/mirc.md
+++ b/content/kb/sasl/mirc.md
@@ -4,7 +4,7 @@ The most recent solution for enabling SASL in mIRC appears to be with sasl.mrc, 
 
 # Configuring SASL for mIRC: sasl.mrc
 
-The mirc script is written by Kyle Travaglini and was originally taken from a [SwiftIRC forum post](http://forum.swiftirc.net/viewtopic.php?f=34&t=23101). The SwiftIRC version has been replaced by a version that does not require the DLL. The instructions have been updated by KindOne.
+The mirc script is written by Kyle Travaglini and was originally taken from a [SwiftIRC forum post <i class="fa fa-external-link" aria-hidden="true"></i>](http://forum.swiftirc.net/viewtopic.php?f=34&t=23101). The SwiftIRC version has been replaced by a version that does not require the DLL. The instructions have been updated by KindOne.
 
 1. Start mIRC and where you would type text to send to a channel, type `/run` and hit Enter. A folder will open. Take note of this location.
 2. Download sasl.mrc and save it in the folder from above. You may need to right click and select `Save Link As...`

--- a/content/kb/sasl/mirc.md
+++ b/content/kb/sasl/mirc.md
@@ -1,0 +1,29 @@
+Title: Configuring SASL for mIRC
+---
+The most recent solution for enabling SASL in mIRC appears to be with sasl.mrc, the first of the options documented below. Some older solutions have also been reported, with varying degrees of success. They are still listed here in case the first option does not work.
+
+# Configuring SASL for mIRC: sasl.mrc
+
+The mirc script is written by Kyle Travaglini and was originally taken from a [SwiftIRC forum post](http://forum.swiftirc.net/viewtopic.php?f=34&t=23101). The SwiftIRC version has been replaced by a version that does not require the DLL. The instructions have been updated by KindOne.
+
+1. Start mIRC and where you would type text to send to a channel, type `/run` and hit Enter. A folder will open. Take note of this location.
+2. Download sasl.mrc and save it in the folder from above. You may need to right click and select `Save Link As...`
+3. In mIRC, click Tools then Scripts Editor
+4. Click on the Remotes tab, then on File and Load. Find and load sasl.mrc.
+5. You will see a warning about scripts that include initialization commands. You will need to click Yes to finish loading the SASL script.
+6. Go back to the main mIRC window, and click Commands, then mSASL v1.0 Beta [sans DLL].
+7. Either select the entry for freenode or click Add. (See below.)
+8. Fill in Network (if applicable). This must exactly match the network in the server list.
+9. In Username, enter your registered nickname. Enter your NickServ password in the NS Password field. Domain should be 0, and AuthType should be `PLAIN`.
+10. Click OK twice to close the dialog boxes.
+
+If everything has been configured correctly, the next time you connect you should see the message:
+`SASL authentication successful`
+
+The server address when you connect must match the server address in the server list. You can check this by typing alt+e, finding the freenode folder, expanding and clicking a server, then clicking Edit. If you don't use the server listed here, the script won't work.
+
+If NickServ is unavailable when you connect, then the script will fail and loop repeatedly trying to connect repeatedly until NickServ is back.
+
+Remember to update your settings if you change your NickServ account name or password.
+
+Your nick and password are stored in a plain text file, `sasl.hsh`, in the same folder as the script.

--- a/content/kb/sasl/textual.md
+++ b/content/kb/sasl/textual.md
@@ -1,0 +1,20 @@
+Title: Configuring SASL for Textual
+---
+Textual is a lightweight IRC client for Mac OS X. Textual supports SASL out of the box without any additional scripts or plugins.
+
+To set up SASL you need to know your NickServ account name, which you can find with /msg NickServ INFO.
+
+To set up a new server with SASL:
+
+1. Go to the Server menu and select "Add Server"
+2. Set up freenode as you would normally, with the hostname chat.freenode.net
+3. Go to the "Identity" tab
+4. Fill in your nickname, then put your NickServ account name in the "Username" field and your NickServ password in the "Personal Password" field
+5. Save and connect
+
+For an existing server:
+
+1. Go to the Server menu and select "Server Properties"
+2. Go to the "Identity" tab
+3. Fill in your nickname, then put your NickServ account name in the "Username" field and your NickServ password in the "Personal Password" field
+4. Save and reconnect

--- a/content/kb/sasl/znc.md
+++ b/content/kb/sasl/znc.md
@@ -1,0 +1,13 @@
+Title: Configuring SASL for ZNC
+---
+ZNC ≥1.0 includes an official SASL module. Details can be found on the [ZNC wiki](http://wiki.znc.in/Sasl).
+
+1. Load the SASL module as you would any other module, following the instructions here.
+
+2. Configure the supported mechanisms:
+    `/msg *sasl Mechanism PLAIN`
+
+3. Configure your authentication credentials. AccountName should be the primary nick. Replace Password with your Nickserv password.
+`/msg *sasl Set AccountName Password`
+
+The next time ZNC reconnects, it should identify automatically.

--- a/content/kb/sasl/znc.md
+++ b/content/kb/sasl/znc.md
@@ -1,6 +1,6 @@
 Title: Configuring SASL for ZNC
 ---
-ZNC ≥1.0 includes an official SASL module. Details can be found on the [ZNC wiki](http://wiki.znc.in/Sasl).
+ZNC ≥1.0 includes an official SASL module. Details can be found on the [ZNC wiki <i class="fa fa-external-link" aria-hidden="true"></i>](http://wiki.znc.in/Sasl).
 
 1. Load the SASL module as you would any other module, following the instructions here.
 

--- a/content/kb/using/sasl.md
+++ b/content/kb/using/sasl.md
@@ -8,17 +8,17 @@ SASL Client Configuration
 
 We have instructions on how to configure SASL for some client, below. If asked to choose an authentication mechanism, be aware that freenode does not support `DH-BLOWFISH` or `EXTERNAL`
 
-* [AndChat](http://www.andchat.net/page/misc_doc)
-* [AndroIRC](http://wiki.androirc.com/nickserv_sasl)
+* [AndChat <i class="fa fa-external-link" aria-hidden="true"></i>](http://www.andchat.net/page/misc_doc)
+* [AndroIRC <i class="fa fa-external-link" aria-hidden="true"></i>](http://wiki.androirc.com/nickserv_sasl)
 * [Chatzilla](kb/sasl/chatzilla)
 * [EPIC5](kb/sasl/epic5)
 * [HexChat](kb/sasl/hexchat)
 * [irssi](kb/sasl/irssi)
-* [Konversation](http://userbase.kde.org/Konversation/Configuring_SASL_authentication)
+* [Konversation <i class="fa fa-external-link" aria-hidden="true"></i>](http://userbase.kde.org/Konversation/Configuring_SASL_authentication)
 * [KVIrc](kb/sasl/kvirc)
 * [mirc](kb/sasl/mirc)
 * [Textual](kb/sasl/textual)
-* [Weechat](https://www.weechat.org/files/doc/stable/weechat_user.en.html#irc_sasl_authentication)
+* [Weechat <i class="fa fa-external-link" aria-hidden="true"></i>](https://www.weechat.org/files/doc/stable/weechat_user.en.html#irc_sasl_authentication)
 * [ZNC](kb/sasl/znc)
 
 If you know of any additions or corrections to the lists above, or would like to contribute a script or (better) documentation, contact us on IRC.

--- a/content/kb/using/sasl.md
+++ b/content/kb/using/sasl.md
@@ -1,0 +1,33 @@
+Title: Connecting with SASL
+---
+SASL is a method that allows identification to services (NickServ) during the connection process, before anything else happens - therefore eliminating the need to 
+/msg nickserv identify. To use SASL, you must [register your nickname](#XXXkb/using/registration).
+
+Some users may see this message when connecting:
+```
+*** Notice -- You need to identify via SASL to use this server
+```
+When there are repeated problems with abuse or anti-social behavior from an IP range, and the users on that IP range seem to have the ability to rapidly change 
+between many different IPs, freenode is left with the uncomfortable choices of completely blocking access to the entire range, doing nothing, or turning to SASL. 
+If nothing is done, many large channels may end up blocking entire ISPs and countries, perhaps for an extended time. SASL allows freenode to avoid a complete block 
+while still mitigating potential abuse.
+
+SASL Client Configuration
+==============
+
+We have instructions on how to configure SASL for some client, below. If asked to choose an authentication mechanism, be aware that freenode does not support `DH-BLOWFISH` or `EXTERNAL`
+
+* (AndChat)[http://www.andchat.net/page/misc_doc]
+* (AndroIRC)[http://wiki.androirc.com/nickserv_sasl]
+* (Chatzilla)[http://freenode-dev.net/sasl/sasl-chatzilla.shtml]
+* (EPIC5)[http://freenode-dev.net/sasl/sasl-epic5.shtml]
+* (HexChat)[http://freenode-dev.net/sasl/sasl-hexchat.shtml]
+* (irssi)[http://freenode-dev.net/sasl/sasl-irssi.shtml]
+* (Konversation)[http://userbase.kde.org/Konversation/Configuring_SASL_authentication]
+* (KVIrc)[http://freenode-dev.net/sasl/sasl-kvirc.shtml]
+* (mirc)[http://freenode-dev.net/sasl/sasl-mirc.shtml]
+* (Textual)[http://freenode-dev.net/sasl/sasl-textual.shtml]
+* (Weechat)[https://www.weechat.org/files/doc/stable/weechat_user.en.html#irc_sasl_authentication]
+* (ZNC)[http://freenode-dev.net/sasl/sasl-znc.shtml]
+
+If you know of any additions or corrections to the lists above, or would like to contribute a script or (better) documentation, contact us on IRC.

--- a/content/kb/using/sasl.md
+++ b/content/kb/using/sasl.md
@@ -1,33 +1,24 @@
 Title: Connecting with SASL
 ---
-SASL is a method that allows identification to services (NickServ) during the connection process, before anything else happens - therefore eliminating the need to 
-/msg nickserv identify. To use SASL, you must [register your nickname](#XXXkb/using/registration).
-
-Some users may see this message when connecting:
-```
-*** Notice -- You need to identify via SASL to use this server
-```
-When there are repeated problems with abuse or anti-social behavior from an IP range, and the users on that IP range seem to have the ability to rapidly change 
-between many different IPs, freenode is left with the uncomfortable choices of completely blocking access to the entire range, doing nothing, or turning to SASL. 
-If nothing is done, many large channels may end up blocking entire ISPs and countries, perhaps for an extended time. SASL allows freenode to avoid a complete block 
-while still mitigating potential abuse.
+SASL is a method that allows identification to services (NickServ) during the connection process, before anything else happens - therefore eliminating the need to
+/msg nickserv identify. To use SASL, you must [register your nickname](kb/using/registration).
 
 SASL Client Configuration
 ==============
 
 We have instructions on how to configure SASL for some client, below. If asked to choose an authentication mechanism, be aware that freenode does not support `DH-BLOWFISH` or `EXTERNAL`
 
-* (AndChat)[http://www.andchat.net/page/misc_doc]
-* (AndroIRC)[http://wiki.androirc.com/nickserv_sasl]
-* (Chatzilla)[http://freenode-dev.net/sasl/sasl-chatzilla.shtml]
-* (EPIC5)[http://freenode-dev.net/sasl/sasl-epic5.shtml]
-* (HexChat)[http://freenode-dev.net/sasl/sasl-hexchat.shtml]
-* (irssi)[http://freenode-dev.net/sasl/sasl-irssi.shtml]
-* (Konversation)[http://userbase.kde.org/Konversation/Configuring_SASL_authentication]
-* (KVIrc)[http://freenode-dev.net/sasl/sasl-kvirc.shtml]
-* (mirc)[http://freenode-dev.net/sasl/sasl-mirc.shtml]
-* (Textual)[http://freenode-dev.net/sasl/sasl-textual.shtml]
-* (Weechat)[https://www.weechat.org/files/doc/stable/weechat_user.en.html#irc_sasl_authentication]
-* (ZNC)[http://freenode-dev.net/sasl/sasl-znc.shtml]
+* [AndChat](http://www.andchat.net/page/misc_doc)
+* [AndroIRC](http://wiki.androirc.com/nickserv_sasl)
+* [Chatzilla](kb/sasl/chatzilla)
+* [EPIC5](kb/sasl/epic5)
+* [HexChat](kb/sasl/hexchat)
+* [irssi](kb/sasl/irssi)
+* [Konversation](http://userbase.kde.org/Konversation/Configuring_SASL_authentication)
+* [KVIrc](kb/sasl/kvirc)
+* [mirc](kb/sasl/mirc)
+* [Textual](kb/sasl/textual)
+* [Weechat](https://www.weechat.org/files/doc/stable/weechat_user.en.html#irc_sasl_authentication)
+* [ZNC](kb/sasl/znc)
 
 If you know of any additions or corrections to the lists above, or would like to contribute a script or (better) documentation, contact us on IRC.


### PR DESCRIPTION
Added documentation for SASL connections, but we really need to sort out a hierarchy for the KB, particularly as adding the SASL documentation makes it looks like the image attached

![screen shot 2016-04-20 at 23 15 05](https://cloud.githubusercontent.com/assets/1158289/14692250/db5d9ce8-074d-11e6-8d6e-650b5a740a0c.png)
