### PR TITLE
Two columns per row on footer when width is 600px-800px

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -40,6 +40,7 @@
 @custom-media --max-sm all and (max-width: 600px);
 @custom-media --max-md all and (max-width: 800px);
 @custom-media --max-rem all and (max-width: 60rem);
+@custom-media --sm-md (--max-md) and (min-width: 600px);
 
 /* reset css for browser compat */
 * {
@@ -663,6 +664,24 @@ footer a:hover {
     .footerchild ul li img,
     .footerchild ul li .fa-fw {
         height: 2.5rem;
+    }
+}
+
+@media (--sm-md) {
+    .footer-container {
+        flex-flow: row wrap;
+        position: relative;
+        width: 75vw;
+    }
+
+    .footerchild {
+        flex-basis: 40%;
+        margin: 0;
+        margin-bottom: 1em;
+    }
+
+    .footer-push {
+        margin-left: 0;
     }
 }
 


### PR DESCRIPTION
Fixes #129 

<600px;
![freenode-600px](https://cloud.githubusercontent.com/assets/14175669/16356306/7a34c362-3ac2-11e6-923b-24a80db4ba33.png)

>600px, <800px;
![freenode-600-800px](https://cloud.githubusercontent.com/assets/14175669/16356310/8b908786-3ac2-11e6-8cec-223cfeb79bdd.png)

>800px;
![freenode-800px](https://cloud.githubusercontent.com/assets/14175669/16356313/97a4582c-3ac2-11e6-8d60-6e1b83667064.png)


