### PR TITLE
use id attribute for anchor element

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -35,7 +35,7 @@
         {% block content %}{% endblock %}
     </div>
     <div class="footers">
-        <a name="navigation"></a>
+        <a id="navigation"></a>
         {% include "footer.html" %}
     </div>
 </body>


### PR DESCRIPTION
name is obsolete and now non-standard.

Signed-off-by: Alex Fluter <afluter@gmail.com>