### PR TITLE
certfp: Add -nodes to the openssl commandline

### DIFF
--- a/content/kb/using/certfp.md
+++ b/content/kb/using/certfp.md
@@ -14,7 +14,7 @@ you are using Windows and do not have a copy, you might consider using Cygwin.
 
 You can generate a certificate with the following command:
 
-    openssl req -x509 -new -newkey rsa:4096 -sha256 -days 1000 -out freenode.pem -keyout freenode.pem
+    openssl req -x509 -new -newkey rsa:4096 -sha256 -days 1000 -nodes -out freenode.pem -keyout freenode.pem
 
 You will be prompted for various pieces of information about the certificate.
 The contents do not matter for our purposes, but `openssl` needs at least one of


### PR DESCRIPTION
It disables passphrase support.

At least hexchat, weechat and ZNC don't support this (haven't tested
others), and irssi does, but the passphrase is stored in plaintext in
the config, making it pointless. And the instructions below don't
mention the parameter to add the passphrase (-ssl_pass)