### PR TITLE
Fixing typo at the groupreg page

### DIFF
--- a/content/pages/groupreg.md
+++ b/content/pages/groupreg.md
@@ -10,7 +10,7 @@ represents an official relationship with freenode.
 ### On-topic groups
 
 Groups considered to be on-topic for Freenode are primarily free and open-source
-software projects, and other peer-directed projeccts, for instance Linux User
+software projects, and other peer-directed projects, for instance Linux User
 Groups (LUGs), student societies, and other colloborative efforts, or projects/companies
 of general interest to our user base.
 


### PR DESCRIPTION
There was a typo at the groupreg page, "projeccts". This commit fixes it.