### PR TITLE
Add new Fedora AMA Blog Post

### DIFF
--- a/content/news/2017-01-21-fedora-ama.md
+++ b/content/news/2017-01-21-fedora-ama.md
@@ -1,0 +1,26 @@
+---
+Title: Fedora AMA
+Author: Nathan Handler (nhandler)
+Date: 2017-01-21 15:24Z
+Slug: fedora-ama
+---
+
+The [freenode Community Team](news/2016-10-14-community) is pleased to announce a new
+opportunity to learn about one of our many groups on freenode.
+Justin W. Flory (jflory7) from the Fedora project has agreed to follow-up on
+his recent [blog post](news/2016-12-21-celebrating-fedora-freenode) with an "Ask Me
+Anything" (AMA) session.
+
+For those of you who might not be familiar with an AMA, as its name suggests,
+it is an opportunity for you to ask the Fedora project all of those questions
+that you have been wondering. You can ask about the project itself, how they
+utilize freenode, ways to start contributing, or any other topics you might be
+interested in learning more about.
+
+The session is scheduled to take place on Wed Jan 25 18:00:00 UTC 2017.
+You can watch the AMA in `#freenode-ama` and participate by asking questions in
+`#freenode-ama-questions` during the session.
+
+We hope to hold more Ask Me Anything sessions in the future. If this is something
+your project would be interested in, please reach out to us in `#freenode-community`
+or at <community@freenode.net>.


### PR DESCRIPTION
This adds a new blog post announcing the Fedora Ask Me Anything session that will be taking place on January 25, 2017 in `#freenode-ama`.