### PR TITLE
SASL irssi: add /network to old-version steps

### DIFF
--- a/content/kb/sasl/irssi.md
+++ b/content/kb/sasl/irssi.md
@@ -24,6 +24,7 @@ You can install it from <https://scripts.irssi.org>:
 Now load and configure it inside Irssi:
 
     /script load cap_sasl
+    /network add freenode
     /server add -auto -net freenode -ssl -ssl_verify irc.freenode.net 6697
     /sasl set freenode <login> <password> PLAIN
     /sasl save


### PR DESCRIPTION
Old-version irssi SASL will usually work without a /network add because a "freenode" network already exists on most distro default configs, but won't work with a blank config. This happened in #freenode today, so adding it to documentation.