### PR TITLE
Warn about broken links on WP entry header

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -8,7 +8,7 @@
         This article was imported from freenode's wordpress blog, and is
         likely out of date. It's preserved here in the interest of
         history, but please don't treat it as an authoritative source in
-        any context.
+        any context. Links on this page may be out of date and broken.
     </div>
     {%- endif %}
     <div class="art-info">


### PR DESCRIPTION
People keep complaining in #freenode about links on decade-old blog posts being broken. One "easy win" for this is warning about that in the header; long-term there should be a redirect or old posts should be edited to point to an informative interstitial page, but this is better than nothing.