### PR TITLE
Add konversation instructions for certs

### DIFF
--- a/content/kb/using/certfp.md
+++ b/content/kb/using/certfp.md
@@ -87,6 +87,20 @@ that the `certs` directory does not exist by default and you will have to
 create it yourself. Once the file is there, all subsequent SSL connections to
 that network will use the certificate.
 
+Konversation
+------------
+
+Create the pem file as per above, then place it wherever you want. 
+Start Konversation, then open the Identity dialogue by either pressing F8
+or via the Settings menu entry. Choose the identity you use for the 
+freenode network or create a new one. 
+In the part `Auto Identity` you have to choose `SASL External (Cert)`
+as the `Type` for SASL External or `SSL CLient Certificate` for CertFP.
+SASL External requires at least version 1.7 of Konversation. 
+Optionally fill in your account name in the `Account`field. 
+You can then choose the certificate you created with the file picker
+or enter the path manually in the field next to it.
+Once done, apply the configuration and (re)connect to freenode.
 
 Add your fingerprint to NickServ
 ================================


### PR DESCRIPTION
Please pull this around when 1.7 is released, which is in ~2 weeks.  1.7rc is out and can be tested. 

Adds instructions on how to use certs for CertFP  (already available) and SASL external (>= 1.7). 