### PR TITLE
Fix preformatted code block for alis help text.

### DIFF
--- a/content/kb/using/findingchannels.md
+++ b/content/kb/using/findingchannels.md
@@ -21,48 +21,46 @@ channels in the freenode namespace with at least 10 users.
 For full details on how to use alis, `/msg alis HELP LIST` will send you back
 the following help text:
 
-```
-***** alis Help *****
-Help for LIST:
- 
-LIST gives a list of channels matching the
-pattern, modified by the other options.
- 
-Syntax: LIST <pattern> [options]
- 
-Options are:
-    -min <n>: show only channels with at least <n> users
-    -max <n>: show only channels with at most <n> users
-    -skip <n>: skip first <n> matches
-    -show [m][t]: show modes/topicsetter
-    -mode <+|-|=><modes>: modes set/unset/equal
-    -topic <pattern>: topic matches pattern
-    -showsecret: show secret channels (requires chan:auspex)
- 
-The pattern can contain * and ? wildcards. The pattern has to
-match the full channel name or a full topic, depending on where it
-is used; the wildcards are important. The pattern is also
-automatically surrounded by * wildcards if
- a channel name pattern starts with a wildcard or a #, or
- a topic pattern contains no * wildcards.
- 
-For example, for channel names, from most to least specific:
- ?bar       - any character followed by "bar" with no other characters
- #bar*      - anything starting with "#bar"
- ##*bar*    - anything starting with ## and containing "bar"
- *cows*moo* - anything containing "cows", 0 or more characters, and "moo"
- *bar*      - anything containing "bar" (equivalent to "bar")
- 
-Examples:
-    /msg alis LIST searchterm
-    /msg alis LIST * -topic multiple*ordered*search*terms
-    /msg alis LIST * -min 50
-    /msg alis LIST #foo*
-    /msg alis LIST #foo* -mode =n
-    /msg alis LIST *freetopic* -mode -t -show mt
-    /msg alis LIST ##nocolors* -mode +c -show t
-***** End of Help *****
-```
+    ***** alis Help *****
+    Help for LIST:
+    
+    LIST gives a list of channels matching the
+    pattern, modified by the other options.
+    
+    Syntax: LIST <pattern> [options]
+    
+    Options are:
+        -min <n>: show only channels with at least <n> users
+        -max <n>: show only channels with at most <n> users
+        -skip <n>: skip first <n> matches
+        -show [m][t]: show modes/topicsetter
+        -mode <+|-|=><modes>: modes set/unset/equal
+        -topic <pattern>: topic matches pattern
+        -showsecret: show secret channels (requires chan:auspex)
+    
+    The pattern can contain * and ? wildcards. The pattern has to
+    match the full channel name or a full topic, depending on where it
+    is used; the wildcards are important. The pattern is also
+    automatically surrounded by * wildcards if
+    a channel name pattern starts with a wildcard or a #, or
+    a topic pattern contains no * wildcards.
+    
+    For example, for channel names, from most to least specific:
+    ?bar       - any character followed by "bar" with no other characters
+    #bar*      - anything starting with "#bar"
+    ##*bar*    - anything starting with ## and containing "bar"
+    *cows*moo* - anything containing "cows", 0 or more characters, and "moo"
+    *bar*      - anything containing "bar" (equivalent to "bar")
+    
+    Examples:
+        /msg alis LIST searchterm
+        /msg alis LIST * -topic multiple*ordered*search*terms
+        /msg alis LIST * -min 50
+        /msg alis LIST #foo*
+        /msg alis LIST #foo* -mode =n
+        /msg alis LIST *freetopic* -mode -t -show mt
+        /msg alis LIST ##nocolors* -mode +c -show t
+    ***** End of Help *****
 
 An alternative method to search is to do so via the web, using
 [netsplit.de](http://irc.netsplit.de/channels/?net=freenode).


### PR DESCRIPTION
Apparently, code/preformatted text surrounded in three backticks is an extra
markdown feature supported by GitHub and others, but not part of the core
Markdown "spec" so didn't work here.