### PR TITLE
Fix bullet points in privacy policy section

### DIFF
--- a/content/pages/policies.md
+++ b/content/pages/policies.md
@@ -158,6 +158,7 @@ freenode may collect the following information:
 Collecting the above data helps freenode deliver its services to you.
 
 Specifically, freenode may use data:
+
 * To improve the provided services.
 * To enable you to reset your password/recover your account.
 * To contact you in relation to group registrations and associated channel namespace management.

--- a/content/pages/policies.md
+++ b/content/pages/policies.md
@@ -145,25 +145,20 @@ If you are asked to provide information when using freenode services, such infor
 freenode collects and uses certain information about users in order to provide services and enable certain functions.
 
 freenode may collect the following information:
-<ul>
-  <li>Nickname/handle on the freenode network</li>
-  <li>E-mail address</li>
-  <li>IP address/hostname</li>
-  <li>Name and project affiliation</li>
-</ul>
+
+* Nickname/handle on the freenode network
+* E-mail address
+* IP address/hostname
+* Name and project affiliation
 
 Collecting the above data helps freenode deliver its services to you.
 
 Specifically, freenode may use data:
-<ul>
-  <li>To improve the provided services.</li>
-<li>To enable you to reset your password/recover your account.</li>
-<li>To contact you in relation to group registrations and associated channel namespace management.</li>
-<li>To respond to a specific enquiry made via e-mail or the support system.</li>
-<li>To provide information in connection with conference registrations, sponsorship enquiries and similar relating to the freenode network and freenode #live conference.</li>
-  </ul>
-  
-
+* To improve the provided services.
+* To enable you to reset your password/recover your account.
+* To contact you in relation to group registrations and associated channel namespace management.
+* To respond to a specific enquiry made via e-mail or the support system.
+* To provide information in connection with conference registrations, sponsorship enquiries and similar relating to the freenode network and freenode #live conference.
 
 Please note that the freenode websites and network may contain links to other websites, and freenode has no control of websites outside of the freenode.net and freenode.live domains. If you provide information to a website or service to which freenode links, freenode shall not be responsible for its protection and privacy.
 


### PR DESCRIPTION
Convert bullets in privacy policy section to use markdown * syntax instead of HTML tags.

I don't have a local copy of web-7.0 to test this on, but this matches the markup used earlier in the same page so I think it'll work?