### PR TITLE
channelmodes.md: Add newline before second table

### DIFF
--- a/content/kb/using/channelmodes.md
+++ b/content/kb/using/channelmodes.md
@@ -38,6 +38,7 @@ To unset a mode, use `/mode #channel -(mode)`
 
 # Restricted channel modes
 The following channel modes can only be added by freenode staff.
+
 | Mode (Name)        | Description                               |
 |--------------------|-------------------------------------------|
 | L (Large Ban List) | Increase maximum number of +beIq entries. |


### PR DESCRIPTION
Markdown hates things being right after paragraphs without a blank line in between, and as a result decided to eat a table and then throw it back up. Theoretically, adding a newline here should fix it. I don't have a local copy of web-7.0 to test, but I do have some painful experience with markdown tables and also with markdown eating things because of missing newlines.

Please check staff channel scrollback/highlights from around 2019-05-07 18:01UTC and 18:38UTC before committing.