### PR TITLE
CertFP: use client.pem on hexchat

### DIFF
--- a/content/kb/using/certfp.md
+++ b/content/kb/using/certfp.md
@@ -82,12 +82,11 @@ Refer to znc's [official documentation](http://wiki.znc.in/Cert).
 HexChat
 -------
 
-The pem file should be placed in `certs/network name.pem` in the HexChat config
-directory (`~/.config/hexchat/` or `%appdata%\HexChat`), where `network name`
-is the name of the network as it appears in the network list (Ctrl-S). Note
+Place the pem file in `certs/client.pem` in the HexChat config
+directory (`~/.config/hexchat/` or `%appdata%\HexChat`). Note
 that the `certs` directory does not exist by default and you will have to
-create it yourself. Once the file is there, all subsequent SSL connections to
-that network will use the certificate.
+create it yourself. Once the file is there, all subsequent SSL connections
+will use the certificate.
 
 Konversation
 ------------

--- a/content/kb/using/certfp.md
+++ b/content/kb/using/certfp.md
@@ -88,6 +88,12 @@ that the `certs` directory does not exist by default and you will have to
 create it yourself. Once the file is there, all subsequent SSL connections
 will use the certificate.
 
+If you connect to multiple IRC networks, you should keep in mind that using the
+filename `certs/client.pem` will send the same certificate to all networks. If
+you prefer per-network certificates, use the name of the network exactly 
+as it appears in the network list (Ctrl-S), including capitalisation and
+punctuation (e.g. `certs/freenode.pem` or `certs/Example Server.pem`).
+
 Konversation
 ------------
 


### PR DESCRIPTION
HexChat supports naming the TLS cert `client.pem` instead of messing around with network names. This is significantly less confusing and almost nobody needs different TLS certs for different networks, so let's go with it instead. Thanks to MetaNova for the info.