### PR TITLE
easier instructions for sasl with weechat

### DIFF
--- a/content/kb/sasl/weechat.md
+++ b/content/kb/sasl/weechat.md
@@ -1,0 +1,22 @@
+Title: Configuring SASL for WeeChat
+---
+
+Here's a simple guide for password-based authentication, based on the [WeeChat quick-start guide <i class="fa fa-external-link" aria-hidden="true"></i>](https://weechat.org/files/doc/stable/weechat_quickstart.en.html).
+
+If you haven't already set up your connection to freenode, use this command:
+
+    /server add freenode chat.freenode.net/6697 -ssl
+
+If you have already set up a connection to freenode, or if that command fails with a message like `irc: server "freenode" already exists, can't add it!`, then use these commands to ensure that SSL/TLS is enabled for your connection:
+
+    /set irc.server.freenode.addresses "chat.freenode.net/6697"
+    /set irc.server.freenode.ssl on
+
+Now, configure SASL:
+
+    /set irc.server.freenode.sasl_mechanism PLAIN
+    /set irc.server.freenode.sasl_username <nickname>
+    /set irc.server.freenode.sasl_password <password>
+    /save
+
+For more complete instructions, including non-password-based mechanisms, see the [official Weechat documentation <i class="fa fa-external-link" aria-hidden="true"></i>](https://www.weechat.org/files/doc/stable/weechat_user.en.html#irc_sasl_authentication).

--- a/content/kb/using/sasl.md
+++ b/content/kb/using/sasl.md
@@ -22,7 +22,7 @@ We have instructions on how to configure SASL for some clients, below. If asked 
 * [mIRC](kb/sasl/mirc)
 * [Quassel](kb/sasl/quassel)
 * [Textual](kb/sasl/textual)
-* [Weechat <i class="fa fa-external-link" aria-hidden="true"></i>](https://www.weechat.org/files/doc/stable/weechat_user.en.html#irc_sasl_authentication)
+* [WeeChat](kb/sasl/weechat)
 * [ZNC <i class="fa fa-external-link" aria-hidden="true"></i>](http://wiki.znc.in/Sasl#example)
 
 If you know of any additions or corrections to the lists above, or would like to contribute a script or (better) documentation, contact us on IRC.


### PR DESCRIPTION
Currently, the SASL instructions for WeeChat are intimidating and do not explicitly describe the most common case (password-based authentication). This is a custom KB page for WeeChat (which also instructs people to enable TLS).

Thanks for your time!