### PR TITLE
Improve readability of cloak request section

### DIFF
--- a/content/kb/general/cloaks.md
+++ b/content/kb/general/cloaks.md
@@ -93,9 +93,9 @@ Requesting a cloak
 ==================
 
 Once you've read and understood the above, if you would like an unaffiliated
-cloak, please drop in to #freenode or speak to a member of the staff team. Note
-that cloaks are a privilege, and staff have the right to deny that privilege to
-users if they deem necessary.
+cloak, please join the #freenode channel or speak to a member of the staff
+team. Note that cloaks are a privilege, and staff have the right to deny that
+privilege to users if they deem necessary.
 
 For project cloaks, a registered GC for the project needs to contact staff to
 request the cloak be added to the desired user.


### PR DESCRIPTION
The "drop in(to)" idiom may confuse non-native / newer users of English, and the spelling here makes it look as if "to" is used as an infinitive (rather than using the preposition "into"), which may exacerbate this confusion.

This PR changes the grammar to be both more direct about the action the user should take, and more consistent with IRC-related terminology. Since the paragraph had to be reflowed for 80 columns, the actual change is:

"please drop in to #freenode" -> "please join the #freenode channel"