### PR TITLE
Registration Skimmability

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A shiny replacement for http://freenode.net.
 You'll need our node.js dependencies:
 
 ```console
-$ sudo npm install -g postcss-cli svgo
+$ sudo npm install -g postcss-cli svgo uglifyjs
 $ npm install
 ```
 

--- a/content/kb/using/registration.md
+++ b/content/kb/using/registration.md
@@ -1,5 +1,8 @@
 Title: Nickname Registration
 ---
+
+<div class="page-variant-registration"></div>
+
 Your nick is how people on freenode know you. If you register it, you'll be able to use the same nick over and over. If you don't register, someone else may end
 up registering the nick you want. If you register and use the same nick, people will begin to know you by reputation.
 
@@ -24,19 +27,11 @@ staff will be happy to discuss it and answer any questions you may have.
 
 2. **Switch** to your desired nickname. This will also be your account name.
 
-    <div class="next-accent">
-
         /nick YourNick
-
-    </div>
 
 3.  **Register** your IRC nick:
 
-    <div class="next-accent">
-
         /msg NickServ REGISTER YourPassword youremail@example.com
-
-    </div>
 
     Replace "YourPassword" with a secure, unguessable password that you keep secret.
 

--- a/content/kb/using/registration.md
+++ b/content/kb/using/registration.md
@@ -1,8 +1,6 @@
 Title: Nickname Registration
 ---
 
-<div class="page-variant-registration"></div>
-
 Your nick is how people on freenode know you. If you register it, you'll be able to use the same nick over and over. If you don't register, someone else may end
 up registering the nick you want. If you register and use the same nick, people will begin to know you by reputation.
 

--- a/content/kb/using/registration.md
+++ b/content/kb/using/registration.md
@@ -3,40 +3,58 @@ Title: Nickname Registration
 Your nick is how people on freenode know you. If you register it, you'll be able to use the same nick over and over. If you don't register, someone else may end
 up registering the nick you want. If you register and use the same nick, people will begin to know you by reputation.
 
-If a channel is set to mode +r, you won't be able to join it unless you are registered and identified to NickServ. If you try to join, you might be forwarded to
-a different channel. If a channel is set to quiet unregistered users (mode `+q $~a`), you won't be able to speak while on that channel unless you are registered
-and identified. Both of these modes are used by some channels to reduce channel harassment and abuse.
+Certain channels require you to register before you may speak in them. The [Unable to Speak](#unable-to-speak) section below explains this further.
 
-Nickname Setup
+Some terms you should know:
+
+- an "account" is your persistent identity
+- a "nickname" is your current display name and can be owned by an account
+- to "identify" means to log into your account
+- "NickServ" is a freenode service that behaves like a user (which you can send private messages to)
+
+Registering
 ==============
 
 The following steps are the recommended method to register and set up a new freenode account. If you have questions or doubts about the process, a member of
 staff will be happy to discuss it and answer any questions you may have.
 
-1.  Select a master, "primary", nickname. If the nickname you want is registered but has expired, just ask a staffer and in most cases, we will be happy to drop
-    it for you. Please avoid using the name of a community project or trademarked entity, to avoid conflicts. Write down your password and be sure to keep the
-    sheet of paper in a safe place.
+1.  **Select** a master, "primary", nickname. If the nickname you want is registered but has expired, just ask a staffer and in most cases, we will be happy to drop
+    it for you. Please avoid using the name of a community project or trademarked entity, to avoid conflicts.
 
-2.  Register your IRC nick:
 
-        /msg NickServ REGISTER password youremail@example.com
+2. **Switch** to your desired nickname. This will also be your account name.
 
-    Replace password with a secure, unguessable password that you keep secret.
+    <div class="next-accent">
+
+        /nick YourNick
+
+    </div>
+
+3.  **Register** your IRC nick:
+
+    <div class="next-accent">
+
+        /msg NickServ REGISTER YourPassword youremail@example.com
+
+    </div>
+
+    Replace "YourPassword" with a secure, unguessable password that you keep secret.
 
     The email address that you select will not be given out by staff, and is mainly used to allow us to help you recover the account in the event that you forget
-    your password. For this reason, you are required to use a real, non-disposable, email address. Upon registering, you will receive an email with a
-    verification command that you will need to run to complete the registration process. Failure to verify the account will cause it to be automatically dropped
-    after about 24 hours.
-    
+    your password. For this reason, you are required to use a real, non-disposable, email address.
+
+    Upon registering, you will receive an email with a verification command that you will need to run to complete the registration process. **Failure to verify** the
+    account will cause it to be automatically **dropped** after about 24 hours.
+
     We do not recommend sharing your NickServ password with anyone else as this could compromise account security and make it harder for you to recover your account in the future.
 
-3.  It's useful, but not required, to have an alternate nick grouped to your account. For example, if your primary nick is foo:
+4.  It's useful, but not required, to have an alternate nick grouped to your account. For example, if your primary nick is "YourNick":
 
-        /nick foo_
+        /nick YourNick2
 
     then identify to your primary account:
 
-        /msg NickServ IDENTIFY foo password
+        /msg NickServ IDENTIFY YourNick YourPassword
 
     and finally, group the new nick to your account
 
@@ -49,12 +67,23 @@ staff will be happy to discuss it and answer any questions you may have.
 Logging In
 ==========
 
-You'll need to log in to your nickname each time you reconnect to freenode.
+You'll need to log in to your account each time you connect to freenode.
 
 The simplest, and most robust, way to do this is to configure [SASL](kb/using/sasl), if your client supports it. If not, you can supply your login details, in
 the form `<account>:<password>`, as a server password and they will be forwarded to NickServ when you finish connecting. For example:
 
-    /connect chat.freenode.net 6667 mquin:uwhY8wgzWw22-zXs.M39p
+    /connect chat.freenode.net 6667 YourNick:YourPassword
+
+Unable to Speak
+==========
+
+If a channel is set to mode `+r`, you won't be able to join it unless you are registered and identified to NickServ. If you try to join, you might be forwarded to
+a different channel. If a channel is set to quiet unregistered users (mode `+q $~a`), you won't be able to speak while on that channel unless you are registered
+and identified.
+
+Both of these modes are used by some channels to reduce channel harassment and abuse.
+
+Once you have registered and are logged in, this issue should disappear.
 
 Nickname Expiry
 ===============
@@ -62,7 +91,7 @@ Nickname Expiry
 Registered nicknames and accounts will expire if they're not used for a long time, after which they'll be available for another user to take over. See our
 [policies](pages/policies) for details of when this occurs.
 
-While nicknames and accounts do not automatically get deleted when they expire -- only when another user requests to take over the registration -- we do
+While nicknames and accounts do not automatically get deleted when they expire—only when another user requests to take over the registration—we do
 occasionally perform clean-up runs on the services database, in which we will automatically drop all registrations which have been idle for a long time. When we
 do this, we set the threshold for deletion considerably higher than the documented expiry time, to ensure that users close to the limit do not lose out.
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -244,7 +244,7 @@ img {
     margin-top: 0;
 }
 
-.main .next-accent + pre {
+.main .page-variant-registration ~ pre, .main .page-variant-registration ~ * pre {
     padding: .5em .75em;
     border-radius: .25em;
     background: var(--c-off-white);

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -244,12 +244,16 @@ img {
     margin-top: 0;
 }
 
-.main .page-variant-registration ~ pre, .main .page-variant-registration ~ * pre {
+
+.main pre {
     padding: .5em .75em;
-    border-radius: .25em;
+    border: 1px solid var(--border-color);
+    overflow-x: auto;
+}
+
+.main pre, .main :not(pre)>code   {
     background: var(--c-off-white);
-    color: var(--c-hl-dark);
-    box-shadow: 0 0 1px  var(--c-bg-light);
+    border-radius: .25em;
 }
 
 .toclink,

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -4,7 +4,6 @@
     --c-bg-dark:  #3a4346;
     --c-bg-light: #4c5456;
     --c-light:    #ecf7fa;
-    --c-off-white: #f9f9f9;
     --c-hl-dark:  #008499;
     --c-hl-light: #3baec4;
     --c-shadow:   #dae5e2;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -247,12 +247,16 @@ img {
 
 .main pre {
     padding: .5em .75em;
-    border: 1px solid var(--border-color);
+    border: 1px solid var(--c-border);
     overflow-x: auto;
 }
 
-.main pre, .main :not(pre)>code   {
-    background: var(--c-off-white);
+.main :not(pre)>code {
+    padding: 0 0.2em;
+}
+
+.main pre, .main :not(pre)>code {
+    background: var(--c-shadow);
     border-radius: .25em;
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -4,6 +4,7 @@
     --c-bg-dark:  #3a4346;
     --c-bg-light: #4c5456;
     --c-light:    #ecf7fa;
+    --c-off-white: #f9f9f9;
     --c-hl-dark:  #008499;
     --c-hl-light: #3baec4;
     --c-shadow:   #dae5e2;
@@ -243,20 +244,12 @@ img {
     margin-top: 0;
 }
 
-
-.main pre {
+.main .next-accent + pre {
     padding: .5em .75em;
-    border: 1px solid var(--c-border);
-    overflow-x: auto;
-}
-
-.main :not(pre)>code {
-    padding: 0 0.2em;
-}
-
-.main pre, .main :not(pre)>code {
-    background: var(--c-shadow);
     border-radius: .25em;
+    background: var(--c-off-white);
+    color: var(--c-hl-dark);
+    box-shadow: 0 0 1px  var(--c-bg-light);
 }
 
 .toclink,


### PR DESCRIPTION
I find it a bit difficult to get the important information out of the registration page, so I took a stab at restructuring it based on my understanding of how users consume text-heavy sites.

[Rendered](https://brigand.github.io/web-7.0/kb/answer/registration)

There are quite a few changes here, and I don't expect all of them to be accepted. The most important one is accenting the command(s) that the user is most likely looking for.

Other changes:

- the technical details about IRC operators setting channel flags isn't super relevant, so moved later in the document
- defining terms used in the document and their relationship up front
- a more distinct "YourPassword" which can't be confused with a keyword as easily
- quoting "YourPassword" to refer to the placeholder in the previous line
- using "YourPassword" consistently
- likewise with "YourNick"
- providing the instruction to switch to the desired nick before registering
- "YourNick2" is more obviously a different name than adding an underscore (unsure about this)
- Using YourNick/YourPassword for `/connect` is more consistent
- from CONTRIBUTING.md: "Do not use hyphens as em dashes"

There's also a small hack used to highlight the primary code block(s) on the page. I'm not sure how to better implement that in markdown. 

CONTRIBUTING.md mentioned needing certain people to review content changes, but I'm not a staff member, so could someone please tag the appropriate people?

Open to feedback or requested changes. I'm more interested in improving this page than getting my specific ideas approved 😄 