### PR TITLE
Update epic5 SASL instructions

### DIFF
--- a/content/kb/sasl/epic5.md
+++ b/content/kb/sasl/epic5.md
@@ -5,6 +5,7 @@ EPIC5 has the sasl_auth script built-in. Mikhail contributed this explanation of
 Open your EPIC5 configuration file, ~/.epicrc or ~/.ircrc, in your preferred editor.
 Add the following lines:
 
+ * `load builtins`
  * `load sasl_auth`
  * `sasl_auth *.freenode.net plain username password`
 


### PR DESCRIPTION
Include advice to load the 'builtins' script as the 'sasl_auth' script depends on it.

Existing users will likely already have 'builtins' included in their configurations, but as it is not loaded by default following our instructions with a fresh installations will result in sasl_auth failing to work.