### PR TITLE
Remove "imported" flag on most recent post

### DIFF
--- a/content/news/2020-02-22-scheduled-maintenance-services-database-spring-cleaning.md
+++ b/content/news/2020-02-22-scheduled-maintenance-services-database-spring-cleaning.md
@@ -5,7 +5,6 @@ slug: scheduled-maintenance-services-database-spring-cleaning
 title: [Scheduled Maintenance] Services database spring cleaning
 category: infrastructure
 category: technical
-imported: no
 ---
 
 During the Easter weekend (April 12th to 15th) we will be purging the freenode services database. 


### PR DESCRIPTION
Should be a simple fix I think, since `imported: no` doesn't do what you'd expect, apparently (could look into the templating to change that, but for now I'm more concerned with removing the inaccurate red warning on the page)