### PR TITLE
Remove the Tor v2 HS from the Chat kb page.

### DIFF
--- a/content/kb/connect/chat.md
+++ b/content/kb/connect/chat.md
@@ -50,11 +50,6 @@ the following hidden service as the server address instead:
 
     ajnvpgl6prmkb7yktvue6im5wiedlz2w32uhcwaamdiecdrfpwwgnlqd.onion
 
-If you are using an old version of Tor (before 0.3.5) that does not support
-v3 addresses, you should instead use the following address:
-
-    freenodeok2gncmy.onion
-
 The hidden service requires SASL authentication. In addition, due to the abuse
 that led Tor access to be disabled in the past, we have unfortunately had to
 add another couple of restrictions:


### PR DESCRIPTION
Version 2 hidden services are on a deprecation path that starts from September and finalises late 2021.
We should probably remove the old .onion from the help docs.

The deprecation to obsolescence timeline from their mailing list:

  1) September 15th, 2020
     0.4.4.x: Tor will start warning onion service operators and clients that
              v2 is deprecated and will be obsolete in version 0.4.6

  2) July 15th, 2021
     0.4.6.x: Tor will no longer support v2 and will be removed from the code
              base.

  3) October 15th, 2021
     We will release new stable versions for all supported series that will
     disable v2.

https://lists.torproject.org/pipermail/tor-dev/2020-June/014365.html