### PR TITLE
Stick to using TLS unless referring to a specific client

### DIFF
--- a/content/kb/connect/chat.md
+++ b/content/kb/connect/chat.md
@@ -8,15 +8,15 @@ ERC, HexChat, Smuxi, Quassel or mIRC.
 
 You can connect to freenode by pointing your IRC client at `chat.freenode.net`
 on ports 6665-6667 and 8000-8002 for plain-text connections, or ports 6697, 7000
-and 7070 for SSL-encrypted connections.
+and 7070 for TLS-encrypted connections.
 
-## Accessing freenode Via SSL
+## Accessing freenode Via TLS
 
-freenode provides SSL client access on all servers, on ports 6697, 7000 and
-7070. Users connecting over SSL will be given user mode +Z, and _is using a
+freenode provides TLS client access on all servers, on ports 6697, 7000 and
+7070. Users connecting over TLS will be given user mode +Z, and _is using a
 secure connection_ will appear in WHOIS (a 671 numeric). Webchat users will not
 currently appear with +Z or the 671 numeric, even if they connect to webchat
-via SSL.
+via TLS.
 
 In order to verify the server certificates on connection, some additional work
 may be required. First, ensure that your system has an up-to-date set of root
@@ -35,7 +35,7 @@ For most clients this should be sufficient. If not, you can download the root
 certificate from
 [LetsEncrypt](https://letsencrypt.org/certificates/).
 
-Client SSL certificates are also supported, and may be used for identification
+Client TLS certificates are also supported, and may be used for identification
 to services. See [this kb article](kb/using/certfp). If you have connected with
 a client certificate, _has client certificate fingerprint
 f1ecf46714198533cda14cccc76e5d7114be4195_ (showing your certificate's SHA1
@@ -63,7 +63,7 @@ If you haven't set up the requisite SASL authentication, we recommend SASL
 EXTERNAL. You'll need to generate a client certificate and add that to your
 NickServ account. This is documented [in our knowledge base](kb/using/certfp).
 
-Connecting using SASL EXTERNAL requires that you connect using SSL encryption.
+Connecting using SASL EXTERNAL requires that you connect using TLS encryption.
 
 You'll then want to tell your client to try the `EXTERNAL` mechanism. We lack
 comprehensive documentation for this, but it's a feature in most modern

--- a/content/kb/using/certfp.md
+++ b/content/kb/using/certfp.md
@@ -6,7 +6,7 @@ Slug: certfp
 As an alternative to password-based authentication, you can connect to freenode
 with a TLS certificate and have services recognise it automatically.
 
-For SASL EXTERNAL to work, you must connect over SSL. 
+For SASL EXTERNAL to work, you must connect over TLS.
 
 Creating a self-signed certificate
 ==================================

--- a/content/kb/using/channelmodes.md
+++ b/content/kb/using/channelmodes.md
@@ -32,7 +32,7 @@ To unset a mode, use `/mode #channel -(mode)`
 | Q<br>(block forwarded users) | Users cannot be forwarded (see +f above) to a channel with +Q. |
 | r<br>(block unidentified) | Prevents users who are not identified to services from joining the channel. |
 | s<br>(secret) | This channel will not appear on channel lists or WHO or WHOIS output unless you are on it. |
-| S<br>(SSL-only) | Only users connected via SSL may join the channel while this mode is set. Users already in the channel are not affected. Keep in mind that this also blocks all webchat users, as they are not marked as connected via SSL. |
+| S<br>(TLS-only) | Only users connected via TLS may join the channel while this mode is set. Users already in the channel are not affected. Keep in mind that this also blocks all webchat users, as they are not marked as connected via TLS. |
 | t<br>(ops topic) | Only channel operators may set the channel topic. |
 | u<br>(unfiltered) | Receive messages that are filtered server side by freenode based on content, usually spam. Set +u if you want the channel to receive these messages. Also see the corresponding user mode. |
 | z<br>(reduced moderation) | The effects of +b, +q, and +m are relaxed. For each message, if that message would normally be blocked by one of these modes, it is instead sent to channel operators (+o). |


### PR DESCRIPTION
Individual client might still refer to SSL in their configuration options and documentation. This commit only changes network information and not client instructions.

This pull request doesn't change any "news" postings; it only changes the knowledge base.

Fixes #443 