### PR TITLE
Add a note about certificate expiry in certfp kb

### DIFF
--- a/content/kb/using/certfp.md
+++ b/content/kb/using/certfp.md
@@ -16,11 +16,12 @@ you are using Windows and do not have a copy, you might consider using Cygwin.
 
 You can generate a certificate with the following command:
 
-    openssl req -x509 -new -newkey rsa:4096 -sha256 -days 1000 -nodes -out freenode.pem -keyout freenode.pem
+    openssl req -x509 -new -newkey rsa:4096 -sha256 -days 1096 -nodes -out freenode.pem -keyout freenode.pem
 
 You will be prompted for various pieces of information about the certificate.
 The contents do not matter for our purposes, but `openssl` needs at least one of
-them to be non-empty.
+them to be non-empty. This certificate will last about 3 years - set a calendar
+event now to ensure that you are reminded when you need to generate a new one.
 
 The `.pem` file will have the same access to your NickServ account as your
 password does, so take appropriate care in securing it.


### PR DESCRIPTION
It seems fairly common that people forget that their certs can expire. Let's add a note in the KB to make them aware of this and suggest a tip to help preempt it.