### PR TITLE
Create groupreg-email

### DIFF
--- a/content/pages/groupreg-email.md
+++ b/content/pages/groupreg-email.md
@@ -1,0 +1,31 @@
+---
+title: Group registration email
+robots: noindex
+---
+
+You have probably landed on this page as part of registering a group on freenode.
+Before you proceed to email us, please make sure you have done the following
+
+* Read about [group registration](/groupreg)
+* Had a look at [freenode's policies](/policies)
+* Discussed your project with a member of the [group management and community team](/groupreg#group-management-community-team)
+
+After you have done so and have been referred to this page, include the following
+details in an email to <projects@freenode.net>.
+
+    # About your project
+    Your project name:
+    Your project blurb:
+    freenode group management team member you have discussed this registration with:
+    
+    Links to places we can find out more about your project:
+    
+    # About you and your staff
+    Your NickServ account (primary group contact):
+    Your relationship to the project:
+    NickServ accounts of alternate group contacts:
+    
+    # About freenode
+    Channels you'd like to claim (typically #projectname):
+    Channel namespaces you'd like to claim (typically #projectname-*):
+    Cloak namespaces you'd like to claim (typically projectname/*):

--- a/content/pages/groupreg-email.md
+++ b/content/pages/groupreg-email.md
@@ -8,7 +8,7 @@ Before you proceed to email us, please make sure you have done the following
 
 * Read about [group registration](/groupreg)
 * Had a look at [freenode's policies](/policies)
-* Discussed your project with a member of the [group management and community team](/groupreg#group-management-community-team), or other member of freenode staff
+* Discussed your project with a member of the group management and community team, or any other member of freenode staff
 
 After you have done so and have been referred to this page, include the following
 details in an email to <projects@freenode.net>.
@@ -16,7 +16,7 @@ details in an email to <projects@freenode.net>.
     # About your project
     Your project name:
     Your project blurb:
-    freenodestaff member you have discussed this registration with:
+    freenode staff member you have discussed this registration with:
     
     Links to places we can find out more about your project:
     

--- a/content/pages/groupreg-email.md
+++ b/content/pages/groupreg-email.md
@@ -8,7 +8,7 @@ Before you proceed to email us, please make sure you have done the following
 
 * Read about [group registration](/groupreg)
 * Had a look at [freenode's policies](/policies)
-* Discussed your project with a member of the [group management and community team](/groupreg#group-management-community-team)
+* Discussed your project with a member of the [group management and community team](/groupreg#group-management-community-team), or other member of freenode staff
 
 After you have done so and have been referred to this page, include the following
 details in an email to <projects@freenode.net>.
@@ -16,7 +16,7 @@ details in an email to <projects@freenode.net>.
     # About your project
     Your project name:
     Your project blurb:
-    freenode group management team member you have discussed this registration with:
+    freenodestaff member you have discussed this registration with:
     
     Links to places we can find out more about your project:
     


### PR DESCRIPTION
Trying to move this to an official place but keep it unlinked so people generally only find it when linked by a member of the groups team when asked to email in.