### PR TITLE
SASL:irssi: add `cd` line when downloading script

### DIFF
--- a/content/kb/sasl/irssi.md
+++ b/content/kb/sasl/irssi.md
@@ -26,8 +26,9 @@ These versions need a separate script in order to support SASL: `cap_sasl.pl`.
 You can install it from <https://scripts.irssi.org>:
 
     mkdir -p ~/.irssi/scripts/autorun
-    wget https://scripts.irssi.org/scripts/cap_sasl.pl -O ~/.irssi/scripts/cap_sasl.pl
-    ln -sf ../cap_sasl.pl ~/.irssi/scripts/autorun/
+    cd ~/.irssi/scripts/autorun
+    wget https://scripts.irssi.org/scripts/cap_sasl.pl -O ../cap_sasl.pl
+    ln -sf ../cap_sasl.pl .
 
 Now load and configure it inside Irssi:
 


### PR DESCRIPTION
Instructions were missing a `cd` line to actually change directory to ~/.irssi/scripts/autorun, which meant the `../cap_sasl.pl` in the last line wouldn't point to the right place. Since having the symlink be relative is useful (in case ~/.irssi/ gets moved later or something), let's add a `cd` and update everything to be relative, rather than making the path in `ln` absolute.