### PR TITLE
show how to get a cert's expiry date in certfp.md

### DIFF
--- a/content/kb/using/certfp.md
+++ b/content/kb/using/certfp.md
@@ -21,7 +21,7 @@ You can generate a certificate with the following command:
 You will be prompted for various pieces of information about the certificate.
 The contents do not matter for our purposes, but `openssl` needs at least one of
 them to be non-empty. This certificate will last about 3 years - you can check the
-expiration date with the following command:
+expiration date with the following command and set a calendar reminder:
 
     cat freenode.pem | openssl x509 -noout -enddate
 

--- a/content/kb/using/certfp.md
+++ b/content/kb/using/certfp.md
@@ -20,8 +20,10 @@ You can generate a certificate with the following command:
 
 You will be prompted for various pieces of information about the certificate.
 The contents do not matter for our purposes, but `openssl` needs at least one of
-them to be non-empty. This certificate will last about 3 years - set a calendar
-event now to ensure that you are reminded when you need to generate a new one.
+them to be non-empty. This certificate will last about 3 years - you can check the
+expiration date with the following command:
+
+    cat freenode.pem | openssl x509 -noout -enddate
 
 The `.pem` file will have the same access to your NickServ account as your
 password does, so take appropriate care in securing it.

--- a/content/kb/using/certfp.md
+++ b/content/kb/using/certfp.md
@@ -23,7 +23,7 @@ The contents do not matter for our purposes, but `openssl` needs at least one of
 them to be non-empty. This certificate will last about 3 years - you can check the
 expiration date with the following command and set a calendar reminder:
 
-    cat freenode.pem | openssl x509 -noout -enddate
+    openssl x509 -in freenode.pem -noout -enddate
 
 The `.pem` file will have the same access to your NickServ account as your
 password does, so take appropriate care in securing it.


### PR DESCRIPTION
think this is a bit more useful than "set a calendar reminder" and we see this kind of convo often

> < user> why has sasl external stopped working
> < sandcat> has your cert expired
> < user> how do i check that