### PR TITLE
Add certificate inspection header

### DIFF
--- a/content/kb/using/certfp.md
+++ b/content/kb/using/certfp.md
@@ -20,7 +20,8 @@ You can generate a certificate with the following command:
 
 You will be prompted for various pieces of information about the certificate.
 The contents do not matter for our purposes, but `openssl` needs at least one of
-them to be non-empty. This certificate will last about 3 years.
+them to be non-empty. This certificate will last about 3 years, so consider setting
+a calendar reminder.
 
 The `.pem` file will have the same access to your NickServ account as your
 password does, so take appropriate care in securing it.
@@ -28,7 +29,7 @@ password does, so take appropriate care in securing it.
 Inspecting your certificate
 ===========================
 
-The expiration date can be checked with the following command and set a calendar reminder:
+The expiration date can be checked with the following command:
 
     openssl x509 -in freenode.pem -noout -enddate
 

--- a/content/kb/using/certfp.md
+++ b/content/kb/using/certfp.md
@@ -20,20 +20,21 @@ You can generate a certificate with the following command:
 
 You will be prompted for various pieces of information about the certificate.
 The contents do not matter for our purposes, but `openssl` needs at least one of
-them to be non-empty. This certificate will last about 3 years - you can check the
-expiration date with the following command and set a calendar reminder:
-
-    openssl x509 -in freenode.pem -noout -enddate
+them to be non-empty. This certificate will last about 3 years.
 
 The `.pem` file will have the same access to your NickServ account as your
 password does, so take appropriate care in securing it.
 
-Under Unix-like environments, the following command:
+Inspecting your certificate
+===========================
+
+The expiration date can be checked with the following command and set a calendar reminder:
+
+    openssl x509 -in freenode.pem -noout -enddate
+
+The fingerprint can be checked with the following command:
 
     openssl x509 -in freenode.pem -outform der | sha1sum -b | cut -d' ' -f1
-
-will list the certificate fingerprint.
-
 
 Connecting to freenode with your certificate
 ============================================


### PR DESCRIPTION
This change helps distinguish the certificate creation commands from the query commands.

User's might gloss over these important commands if they already have a certificate.