### PR TITLE
doc: Update ugligyjs package in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A shiny replacement for http://freenode.net.
 You'll need our node.js dependencies:
 
 ```console
-$ sudo npm install -g postcss-cli@7.1.2 svgo uglifyjs
+$ sudo npm install -g postcss-cli@7.1.2 svgo uglify-js
 $ npm install
 ```
 


### PR DESCRIPTION
Turns out uglifyjs package name has changed:

```
$ npm install -g postcss-cli@7.1.2 svgo uglifyjs
npm WARN deprecated uglifyjs@2.4.11: uglifyjs is deprecated - use uglify-js instead.
```

