### PR TITLE
Add darkness

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -48,7 +48,7 @@
         --background-color:  var(--c-dark);
         --link-color:        #00c8e8;
         --link-hover-color:  #21a9c1;
-        --c-shadow:          #282a29;
+        --c-shadow:          var(--c-bg-light);
         --border-color:      #000000;
         --navbar-border-color: var(--c-dark);
     }
@@ -346,7 +346,7 @@ td:not(:first-child), th:not(:first-child) {
     border-left: 1px solid var(--border-color);
 }
 
-tr:nth-child(odd) {
+tr:nth-child(even) {
     background-color: var(--c-shadow);
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -35,6 +35,7 @@
     --box-hover-color:     var(--c-dark);
     --box-round:           10px;
     --navbar-border-color: var(--border-color);
+    --footer-shadow-color: rgba(150,150,150,.36);
 
     /* other */
     --max-width:     600px;
@@ -51,6 +52,7 @@
         --c-shadow:          var(--c-bg-light);
         --border-color:      #000000;
         --navbar-border-color: var(--c-dark);
+        --footer-shadow-color: rgba(70, 70, 70, 0.5);
     }
 }
 
@@ -636,7 +638,7 @@ blockquote {
     background: var(--jumbotron-bg);
     color: var(--footer-text-color);
     width: 100%;
-    box-shadow: 0 -3px 5px rgba(150,150,150,.36);
+    box-shadow: 0 -3px 5px var(--footer-shadow-color);
     min-height: 15.4rem;
     padding: 3em 0;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -15,10 +15,12 @@
     --copyright-bg: var(--c-dark);
 
     /* link colors */
-    --link-color:         var(--c-hl-dark);
-    --link-hover-color:   var(--c-hl-light);
-    --footer-link-color:  var(--c-light);
-    --footer-hover-color: #fff;
+    --link-color-light:       var(--c-hl-dark);
+    --link-hover-color-light: var(--c-hl-light);
+    --link-color-dark:        #00c8e8;
+    --link-hover-color-dark:  #21a9c1;
+    --footer-link-color:      var(--c-light);
+    --footer-hover-color:     #fff;
 
     /* text colors */
     --text-color-light:     var(--c-dark);
@@ -80,21 +82,21 @@ body {
 }
 
 a {
-    color: var(--link-color);
+    color: var(--link-color-light);
     text-decoration: none;
 }
 
 a:hover {
-    color: var(--link-hover-color);
+    color: var(--link-hover-color-light);
 }
 
 @media (prefers-color-scheme: dark) {
     a {
-        color: var(--link-hover-color);
+        color: var(--link-color-dark);
     }
 
     a:hover {
-        color: var(--link-color);
+        color: var(--link-hover-color-dark);
     }
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -30,10 +30,11 @@
     --background-color: var(--c-light);
 
     /* box colors */
-    --border-color:    var(--c-dark);
-    --box-color:       var(--c-bg-light);
-    --box-hover-color: var(--c-dark);
-    --box-round:       10px;
+    --border-color:        var(--c-dark);
+    --box-color:           var(--c-bg-light);
+    --box-hover-color:     var(--c-dark);
+    --box-round:           10px;
+    --navbar-border-color: var(--border-color);
 
     /* other */
     --max-width:     600px;
@@ -43,12 +44,13 @@
 
 @media (prefers-color-scheme: dark) {
     :root {
-        --text-color:       var(--c-light);
-        --background-color: var(--c-dark);
-        --link-color:       #00c8e8;
-        --link-hover-color: #21a9c1;
-        --c-shadow:         #282a29;
-        --border-color:     var(--c-light);
+        --text-color:        var(--c-light);
+        --background-color:  var(--c-dark);
+        --link-color:        #00c8e8;
+        --link-hover-color:  #21a9c1;
+        --c-shadow:          #282a29;
+        --border-color:      #000000;
+        --navbar-border-color: var(--c-dark);
     }
 }
 
@@ -108,7 +110,7 @@ img {
     flex-wrap: nowrap;
     justify-content: space-between;
     align-items: center;
-    border-bottom: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--navbar-border-color);
     z-index: 100;
     padding-right: 5px;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,13 +1,12 @@
 /* vars */
 :root {
-    --c-dark:         #292f2f;
-    --c-bg-dark:      #3a4346;
-    --c-bg-light:     #4c5456;
-    --c-light:        #ecf7fa;
-    --c-hl-dark:      #008499;
-    --c-hl-light:     #3baec4;
-    --c-shadow-light: #dae5e2;
-    --c-shadow-dark:  #282a29;
+    --c-dark:     #292f2f;
+    --c-bg-dark:  #3a4346;
+    --c-bg-light: #4c5456;
+    --c-light:    #ecf7fa;
+    --c-hl-dark:  #008499;
+    --c-hl-light: #3baec4;
+    --c-shadow:   #dae5e2;
 
     /* backgrounds */
     --navbar-bg:    var(--c-dark);
@@ -15,25 +14,20 @@
     --copyright-bg: var(--c-dark);
 
     /* link colors */
-    --link-color-light:       var(--c-hl-dark);
-    --link-hover-color-light: var(--c-hl-light);
-    --link-color-dark:        #00c8e8;
-    --link-hover-color-dark:  #21a9c1;
-    --footer-link-color:      var(--c-light);
-    --footer-hover-color:     #fff;
+    --link-color:         var(--c-hl-dark);
+    --link-hover-color:   var(--c-hl-light);
+    --footer-link-color:  var(--c-light);
+    --footer-hover-color: #fff;
 
     /* text colors */
-    --text-color-light:     var(--c-dark);
-    --text-color-dark:      var(--c-light);
-
+    --text-color:           var(--c-dark);
     --footer-text-color:    var(--c-light);
     --copyright-text-color: var(--c-light);
     --jumbotron-text-color: var(--c-light);
     --art-date-color:       color(var(--c-dark) tint(50%));
 
     /* background colors */
-    --background-color-light: var(--c-light);
-    --background-color-dark:  var(--c-dark);
+    --background-color: var(--c-light);
 
     /* box colors */
     --border-color:    var(--c-dark);
@@ -46,6 +40,18 @@
     --max-width-box: 800px;
     --margin-box-fa: 5px;
 }
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --text-color:       var(--c-light);
+        --background-color: var(--c-dark);
+        --link-color:       #00c8e8;
+        --link-hover-color: #21a9c1;
+        --c-shadow:         #282a29;
+        --border-color:     var(--c-light);
+    }
+}
+
 @custom-media --max-sm all and (max-width: 600px);
 @custom-media --max-md all and (max-width: 800px);
 @custom-media --max-rem all and (max-width: 60rem);
@@ -63,18 +69,11 @@ body {
     font-family: 'Open Sans', sans-serif;
     font-feature-settings: "lnum";
     font-variant-numeric: lining-nums;
-    color: var(--text-color-light);
-    background-color: var(--background-color-light);
+    color: var(--text-color);
+    background-color: var(--background-color);
     font-size: 14px;
     min-height: 100vh;
     height: auto;
-}
-
-@media (prefers-color-scheme: dark) {
-    body {
-        color: var(--text-color-dark);
-        background-color: var(--background-color-dark);
-    }
 }
 
 .invisible {
@@ -82,22 +81,12 @@ body {
 }
 
 a {
-    color: var(--link-color-light);
+    color: var(--link-color);
     text-decoration: none;
 }
 
 a:hover {
-    color: var(--link-hover-color-light);
-}
-
-@media (prefers-color-scheme: dark) {
-    a {
-        color: var(--link-color-dark);
-    }
-
-    a:hover {
-        color: var(--link-hover-color-dark);
-    }
+    color: var(--link-hover-color);
 }
 
 img {
@@ -280,7 +269,7 @@ img {
 
 .main pre {
     padding: .5em .75em;
-    border: 1px solid var(--c-border);
+    border: 1px solid var(--border-color);
     overflow-x: auto;
 }
 
@@ -289,14 +278,8 @@ img {
 }
 
 .main pre, .main :not(pre)>code {
-    background-color: var(--c-shadow-light);
+    background: var(--c-shadow);
     border-radius: .25em;
-}
-
-@media (prefers-color-scheme: dark) {
-    .main pre, .main :not(pre)>code {
-        background-color: var(--c-shadow-dark);
-    }
 }
 
 .toclink,
@@ -340,14 +323,8 @@ hr {
 }
 
 table {
-    border: 1px solid var(--c-dark);
+    border: 1px solid var(--border-color);
     border-collapse: collapse;
-}
-
-@media (prefers-color-scheme: dark) {
-    table {
-        border: 1px solid var(--c-light);
-    }
 }
 
 th, td {
@@ -364,21 +341,11 @@ td {
 }
 
 td:not(:first-child), th:not(:first-child) {
-    border-left: 1px solid var(--c-dark);
+    border-left: 1px solid var(--border-color);
 }
 
 tr:nth-child(odd) {
-    background-color: var(--c-shadow-light);
-}
-
-@media (prefers-color-scheme: dark) {
-    td:not(:first-child), th:not(:first-child) {
-        border-left: 1px solid var(--c-light);
-    }
-
-    tr:nth-child(odd) {
-        background-color: var(--c-shadow-dark);
-    }
+    background-color: var(--c-shadow);
 }
 
 /* jumbotron */

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,12 +1,13 @@
 /* vars */
 :root {
-    --c-dark:     #292f2f;
-    --c-bg-dark:  #3a4346;
-    --c-bg-light: #4c5456;
-    --c-light:    #ecf7fa;
-    --c-hl-dark:  #008499;
-    --c-hl-light: #3baec4;
-    --c-shadow:   #dae5e2;
+    --c-dark:         #292f2f;
+    --c-bg-dark:      #3a4346;
+    --c-bg-light:     #4c5456;
+    --c-light:        #ecf7fa;
+    --c-hl-dark:      #008499;
+    --c-hl-light:     #3baec4;
+    --c-shadow-light: #dae5e2;
+    --c-shadow-dark:  #282a29;
 
     /* backgrounds */
     --navbar-bg:    var(--c-dark);
@@ -20,11 +21,17 @@
     --footer-hover-color: #fff;
 
     /* text colors */
-    --text-color:           var(--c-dark);
+    --text-color-light:     var(--c-dark);
+    --text-color-dark:      var(--c-light);
+
     --footer-text-color:    var(--c-light);
     --copyright-text-color: var(--c-light);
     --jumbotron-text-color: var(--c-light);
     --art-date-color:       color(var(--c-dark) tint(50%));
+
+    /* background colors */
+    --background-color-light: var(--c-light);
+    --background-color-dark:  var(--c-dark);
 
     /* box colors */
     --border-color:    var(--c-dark);
@@ -54,10 +61,18 @@ body {
     font-family: 'Open Sans', sans-serif;
     font-feature-settings: "lnum";
     font-variant-numeric: lining-nums;
-    color: var(--text-color);
+    color: var(--text-color-light);
+    background-color: var(--background-color-light);
     font-size: 14px;
     min-height: 100vh;
     height: auto;
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        color: var(--text-color-dark);
+        background-color: var(--background-color-dark);
+    }
 }
 
 .invisible {
@@ -72,6 +87,17 @@ a {
 a:hover {
     color: var(--link-hover-color);
 }
+
+@media (prefers-color-scheme: dark) {
+    a {
+        color: var(--link-hover-color);
+    }
+
+    a:hover {
+        color: var(--link-color);
+    }
+}
+
 img {
     max-width: 100%;
 }
@@ -261,8 +287,14 @@ img {
 }
 
 .main pre, .main :not(pre)>code {
-    background: var(--c-shadow);
+    background-color: var(--c-shadow-light);
     border-radius: .25em;
+}
+
+@media (prefers-color-scheme: dark) {
+    .main pre, .main :not(pre)>code {
+        background-color: var(--c-shadow-dark);
+    }
 }
 
 .toclink,
@@ -310,6 +342,12 @@ table {
     border-collapse: collapse;
 }
 
+@media (prefers-color-scheme: dark) {
+    table {
+        border: 1px solid var(--c-light);
+    }
+}
+
 th, td {
     margin: .2em;
 }
@@ -328,7 +366,17 @@ td:not(:first-child), th:not(:first-child) {
 }
 
 tr:nth-child(odd) {
-    background-color: var(--c-shadow);
+    background-color: var(--c-shadow-light);
+}
+
+@media (prefers-color-scheme: dark) {
+    td:not(:first-child), th:not(:first-child) {
+        border-left: 1px solid var(--c-light);
+    }
+
+    tr:nth-child(odd) {
+        background-color: var(--c-shadow-dark);
+    }
 }
 
 /* jumbotron */


### PR DESCRIPTION
Add dark mode support using prefers-color-scheme: dark CSS media query.

Explicitly set default background color in addition to text color in case any browser has non-black-on-white defaults.

<details>
<summary>Screenshots</summary>

![Home page](https://user-images.githubusercontent.com/9721638/106169285-e2535480-6197-11eb-9266-72a9c0b192e3.png)
![Group management page, showing footer](https://user-images.githubusercontent.com/9721638/106169359-f7c87e80-6197-11eb-93b6-e1d481e546e3.png)
![User modes page, showing a table](https://user-images.githubusercontent.com/9721638/106169447-0e6ed580-6198-11eb-863a-c76881035a15.png)

</details>

closes #481