### PR TITLE
SASL: remove AndChat

### DIFF
--- a/content/kb/using/sasl.md
+++ b/content/kb/using/sasl.md
@@ -9,7 +9,6 @@ SASL Client Configuration
 We have instructions on how to configure SASL for some clients, below. If asked to choose an authentication mechanism, be aware that freenode does not support `DH-BLOWFISH`
 
 * [AdiIRC <i class="fa fa-external-link" aria-hidden="true"></i>](https://dev.adiirc.com/projects/adiirc/wiki/SASL)
-* [AndChat <i class="fa fa-external-link" aria-hidden="true"></i>](http://www.andchat.net/page/misc_doc)
 * [AndroIRC <i class="fa fa-external-link" aria-hidden="true"></i>](http://wiki.androirc.com/nickserv_sasl)
 * [Chatzilla](kb/sasl/chatzilla)
 * [EPIC5](kb/sasl/epic5)


### PR DESCRIPTION
AndChat is no longer on the Google Play Store, and its domain appears to have been grabbed by a third party, so let's remove it from the SASL instruction list.