### PR TITLE
SASL: add Ambassador

### DIFF
--- a/content/kb/sasl/ambassador.md
+++ b/content/kb/sasl/ambassador.md
@@ -1,0 +1,7 @@
+Title: Configuring SASL for Ambassador
+---
+In order to use SASL in the [Ambassador](https://github.com/Ascrod/ambassador) client, you simply have to go to Ambassador --> Preferences on the menu bar, and check the "Use SASL Authentication" checkbox. Make sure your nickname matches the nickname(s) you have registered on freenode.
+
+The next time you connect, the client will prompt you for a password, which you can save in your password manager.
+
+If everything has been configured correctly, you should see the message `SASL authentication successful`.

--- a/content/kb/using/certfp.md
+++ b/content/kb/using/certfp.md
@@ -132,6 +132,18 @@ and when you tap this, a certificate will be randomly generated and a certicate
 fingerprint will be displayed. Tap the tick symbol on the top right of the screen
 to save.
 
+Ambassador
+----------
+
+Refer to Ambassador's FAQ in its wiki on [GitHub](https://github.com/Ascrod/ambassador/wiki/FAQ).
+You have to convert the .pem file you created into .pfx. If you're using Ambassador as an
+[add-on](https://addons.palemoon.org/addon/ambassador/) in Pale Moon 29, you need to update the
+browser to 29.1.1, which fixes a regression preventing certificates from being imported. For
+[Basilisk](https://www.basilisk-browser.org/) and [Interlink](https://binaryoutcast.com/projects/interlink/),
+you have to update to v2021.03.17 and 52.9.7762 respectively, which also fix the same issue.
+
+If you're using the standalone version, then it should be straightforward for you.
+
 Add your fingerprint to NickServ
 ================================
 

--- a/content/kb/using/sasl.md
+++ b/content/kb/using/sasl.md
@@ -9,6 +9,7 @@ SASL Client Configuration
 We have instructions on how to configure SASL for some clients, below. If asked to choose an authentication mechanism, be aware that freenode does not support `DH-BLOWFISH`
 
 * [AdiIRC <i class="fa fa-external-link" aria-hidden="true"></i>](https://dev.adiirc.com/projects/adiirc/wiki/SASL)
+* [Ambassador](kb/sasl/ambassador)
 * [AndroIRC <i class="fa fa-external-link" aria-hidden="true"></i>](http://wiki.androirc.com/nickserv_sasl)
 * [Chatzilla](kb/sasl/chatzilla)
 * [EPIC5](kb/sasl/epic5)


### PR DESCRIPTION
This PR adds instructions for SASL on [Ambassador](//github.com/Ascrod/ambassador), a [UXP](//github.com/MoonchildProductions/UXP) fork of ChatZilla.