### PR TITLE
Clarify policy on keeping primary channels open

### DIFF
--- a/content/pages/policies.md
+++ b/content/pages/policies.md
@@ -43,9 +43,9 @@ Channel ownership
 =================
 
 Channels on freenode fall into one of two categories. Primary channels, which
-begin with a single # character, are reserved for on-topic projects. Primary
-channels are required to stay open.  If a primary channel closes access to its
-users or is in violation of freenode policies, then it will be closed and forwarded
+begin with a single # character, are reserved for on-topic projects. Projects are
+required to keep at least one primary channel open. If a project closes access to its
+users or is in violation of freenode policies, then its channels will be closed and forwarded
 to a topical channel. If you’d like to take over one of these primary channels, then
 you’ll need to be associated in some way with the project in question. Topical,
 or ‘about’ channels, begin with two # characters, and these are allocated on a


### PR DESCRIPTION
I don't know if this is the exact policy, but this seems to describe better
what was explained to me on #freenode-services:

```
17:58 <pinkieval> Someone closed a # channel I was in, can you make it forward to the ## channel with the same name, like https://freenode.net/policies#channel-ownership says?
18:01 <@Tabmow> pinkieval: what channel?
18:01 <pinkieval> Tabmow: #freenode-policy-feedback
18:02 <@Tabmow> pinkieval: umm, no. Those are used by freenode staff when needed.
18:02 <pinkieval> So freenode channels are excluded from the policy?
18:05 <@Tabmow> pinkieval: they are part of the freenode group which staff own. Read the policy again.
18:06 <pinkieval> I get it, but the policy says "Primary channels are required to stay open.". #freenode-policy-feedback is a primary channel, right?
18:09 <@Tabmow> pinkieval: there are many freenode primary channels, like this one.
18:10 <pinkieval> So only one primary channel per project needs to stay open?
18:19 <-- Tabmow (~tabmow@freenode/staff/tabmow) a quitté (Quit: ZNC 1.8.2 - https://znc.in)
18:20 --> Tabmow (~tabmow@freenode/staff/tabmow) a rejoint #freenode-services
18:20 -- Mode #freenode-services [+o Tabmow] par ChanServ
18:21 <pinkieval> Tabmow: (in case you missed the question: ) So only one primary channel per project needs to stay open?
18:29 <@Tabmow> pinkieval: not exactly, but sure.
```

(I removed unrelated messages from the log)

Suggestions are welcome to make this closer to the actual policy.