### PR TITLE
people: Fix hyperbolic statements about the staff

### DIFF
--- a/content/pages/people.md
+++ b/content/pages/people.md
@@ -1,7 +1,7 @@
 ---
 Title: The People
 ---
-The freenode project mostly run by volunteers. Most of the current volunteers came to the project through involvement with one or more of the projects that use freenode or other networks and have deep experience running IRC networks.
+The freenode project is mostly run by volunteers. Most of the current volunteers came to the project through involvement with one or more of the projects that use freenode or other networks and have deep experience running IRC networks.
 
 The following people help to keep freenode running:
 

--- a/content/pages/people.md
+++ b/content/pages/people.md
@@ -1,7 +1,7 @@
 ---
 Title: The People
 ---
-The freenode project is run entirely by volunteers. All of the current volunteers came to the project through involvement with one or more of the projects that use freenode and have deep experience running IRC networks.
+The freenode project mostly run by volunteers. Most of the current volunteers came to the project through involvement with one or more of the projects that use freenode or other networks and have deep experience running IRC networks.
 
 The following people help to keep freenode running:
 


### PR DESCRIPTION
The head of freenode is not a volunteer (as rasengan is the director
of Freenode LTD, a for-profit).

Some of the staff have less than two weeks of experience running an IRC network,
and some do not "came to the project through involvement with one or more
of the projects that use freenode" as they were banned from Freenode until last month)